### PR TITLE
Remove json gem and fix indentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source "https://rubygems.org"
 gem 'sinatra', '~> 2.0.3'
-gem 'json', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    json (2.1.0)
     mustermann (1.0.3)
     rack (2.0.5)
     rack-protection (2.0.3)
@@ -17,7 +16,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  json (~> 2.1.0)
   sinatra (~> 2.0.3)
 
 BUNDLED WITH

--- a/web.rb
+++ b/web.rb
@@ -2,45 +2,45 @@ require 'sinatra'
 require 'json'
 
 get '/' do
-    'Battlesnake documentation can be found at' \
-     '<a href=\"https://docs.battlesnake.io\">https://docs.battlesnake.io</a>.'
+  'Battlesnake documentation can be found at' \
+    '<a href=\"https://docs.battlesnake.io\">https://docs.battlesnake.io</a>.'
 end
 
 post '/start' do
-    requestBody = request.body.read
-    requestJson = requestBody ? JSON.parse(requestBody) : {}
+  requestBody = request.body.read
+  requestJson = requestBody ? JSON.parse(requestBody) : {}
 
-    # Example response
-    responseObject = {
-        "color"=> "#fff000",
-    }
+  # Example response
+  responseObject = {
+    "color"=> "#fff000",
+  }
 
-    return responseObject.to_json
+  return responseObject.to_json
 end
 
 post '/move' do
-    requestBody = request.body.read
-    requestJson = requestBody ? JSON.parse(requestBody) : {}
+  requestBody = request.body.read
+  requestJson = requestBody ? JSON.parse(requestBody) : {}
 
-    # Calculate a direction (example)
-    direction = ["up", "right"].sample
+  # Calculate a direction (example)
+  direction = ["up", "right"].sample
 
-    # Example response
-    responseObject = {
-        "move" => direction
-    }
+  # Example response
+  responseObject = {
+    "move" => direction
+  }
 
-    return responseObject.to_json
+  return responseObject.to_json
 end
 
 post '/end' do
-    requestBody = request.body.read
-    requestJson = requestBody ? JSON.parse(requestBody) : {}
+  requestBody = request.body.read
+  requestJson = requestBody ? JSON.parse(requestBody) : {}
 
-    # No response required
-    responseObject = {}
+  # No response required
+  responseObject = {}
 
-    return responseObject.to_json
+  return responseObject.to_json
 end
 
 post '/ping' do


### PR DESCRIPTION
* Use 2 spaces of indent, not 4. Though this is obviously a matter of taste, and usually just a bike-shed discussion, the overwhelming majority of ruby projects use two spaces.
* Remove `json` gem. Ruby has included `json` in stdlib since 2.0, and the gem version is now old. Most projects now avoid the gem (See ex. https://github.com/rails/rails/pull/23453)